### PR TITLE
Main: Replacing heritage in App class from StandardApp by NPSAppManaged

### DIFF
--- a/osc_tui/main.py
+++ b/osc_tui/main.py
@@ -45,7 +45,7 @@ def exit():
 # APPLICATION CLASS
 
 
-class App(npyscreen.StandardApp):
+class App(npyscreen.NPSAppManaged):
     def onStart(self):
         npyscreen.setTheme(npyscreen.Themes.ColorfulTheme)
         self.addForm("MAIN", profileSelector.ProfileSelector,


### PR DESCRIPTION
The official documentation of npyscreen recommends using NPSAppManaged : [official documentation](https://npyscreen.readthedocs.io/application-objects.html).
The application is more stable with NPSAppManaged.