### PR TITLE
Polishing : screen related modifications

### DIFF
--- a/osc_tui/main.py
+++ b/osc_tui/main.py
@@ -47,7 +47,7 @@ def exit():
 
 class App(npyscreen.NPSAppManaged):
     def onStart(self):
-        npyscreen.setTheme(npyscreen.Themes.ColorfulTheme)
+        npyscreen.setTheme(npyscreen.Themes.DefaultTheme)
         self.addForm("MAIN", profileSelector.ProfileSelector,
                      name="osc-tui")
 

--- a/osc_tui/mainForm.py
+++ b/osc_tui/mainForm.py
@@ -40,7 +40,7 @@ class mainMenu(npyscreen.MultiLineAction):
         super().__init__(screen, *args, **keywords)
         self.form = form
         self.cursor_line = SELECTED_BUTTON
-        self.scroll_exit = True
+        self.scroll_exit = False
         self.draw_line_at = draw_line_at
 
     def actionHighlighted(self, act_on_this, key_press):

--- a/osc_tui/mainForm.py
+++ b/osc_tui/mainForm.py
@@ -31,9 +31,9 @@ MODE = "INSTANCES"
 SELECTED_BUTTON = 0
 CURRENT_GRID_CLASS = instancesGrid.InstancesGrid
 
-LINE_SEPARATOR_COL = 17
 MENU_WIDTH = 16
-GRID_START_COL = 19
+LINE_SEPARATOR_COL = MENU_WIDTH + 1
+GRID_START_COL = MENU_WIDTH +3
 
 class mainMenu(npyscreen.MultiLineAction):
     def __init__(self, screen, form=None, draw_line_at=13, *args, **keywords):

--- a/osc_tui/mainForm.py
+++ b/osc_tui/mainForm.py
@@ -31,6 +31,9 @@ MODE = "INSTANCES"
 SELECTED_BUTTON = 0
 CURRENT_GRID_CLASS = instancesGrid.InstancesGrid
 
+LINE_SEPARATOR_COL = 17
+MENU_WIDTH = 16
+GRID_START_COL = 19
 
 class mainMenu(npyscreen.MultiLineAction):
     def __init__(self, screen, form=None, draw_line_at=13, *args, **keywords):
@@ -232,7 +235,7 @@ class MainForm(npyscreen.FormBaseNew):
             mainMenu,
             form=self,
             relx=1,
-            max_width=14,
+            max_width=MENU_WIDTH,
             values=menu_desc,
         )
         y, _ = self.useable_space()
@@ -247,7 +250,7 @@ class MainForm(npyscreen.FormBaseNew):
             column_width=21,
             select_whole_line=True,
             scroll_exit=True,
-            relx=17,
+            relx=GRID_START_COL,
             rely=2,
         )
 
@@ -258,8 +261,8 @@ class MainForm(npyscreen.FormBaseNew):
         _, MAXX = self.curses_pad.getmaxyx()
         super().draw_form()
         MAXX, _ = self.curses_pad.getmaxyx()
-        self.curses_pad.vline(1, 15, curses.ACS_VLINE, MAXX - 2)
-
+        self.curses_pad.vline(1, LINE_SEPARATOR_COL, curses.ACS_VLINE, MAXX - 2)
+    
     def reload(self):
         main.kill_threads()
         self.parentApp.addForm("Cockpit", MainForm, name="osc-tui")

--- a/osc_tui/mainForm.py
+++ b/osc_tui/mainForm.py
@@ -175,7 +175,7 @@ class MainForm(npyscreen.FormBaseNew):
         def build_line(size):
             out = ''
             for i in range(0, size):
-                out = out + '-'
+                out = out + '‎'
             return out
         menu_desc = (
             "INSTANCES SECURITY VOLUMES SNAPSHOT KEYPAIRS IMAGES LBUs VPCs(nets) NET-ACCESS-POINT NET-PEERING GPU REFRESH EXIT " +

--- a/osc_tui/popup.py
+++ b/osc_tui/popup.py
@@ -1,6 +1,7 @@
 import curses
 import textwrap
 from threading import Thread
+import os
 
 import npyscreen
 import npyscreen.fmPopup
@@ -706,11 +707,12 @@ def editSubnet(form, subnet, form_color='STANDOUT'):
 
 
 def startLoading(form, refresh):
+    term_size = os.get_terminal_size()
     class PendingPopup(fmForm.Form):
         DEFAULT_LINES = 7
         DEFAULT_COLUMNS = 12
-        SHOW_ATX = 10
-        SHOW_ATY = 2
+        SHOW_ATX = int(term_size.columns / 2)
+        SHOW_ATY = int(term_size.lines / 2)
 
     def notify(message, title="Loading", form_color='STANDOUT',
                wrap=True, wide=False,

--- a/osc_tui/popup.py
+++ b/osc_tui/popup.py
@@ -711,8 +711,8 @@ def startLoading(form, refresh):
     class PendingPopup(fmForm.Form):
         DEFAULT_LINES = 7
         DEFAULT_COLUMNS = 12
-        SHOW_ATX = int(term_size.columns / 2)
-        SHOW_ATY = int(term_size.lines / 2)
+        SHOW_ATX = int(term_size.columns / 2 - DEFAULT_LINES /2)
+        SHOW_ATY = int(term_size.lines / 2 - DEFAULT_COLUMNS / 2)
 
     def notify(message, title="Loading", form_color='STANDOUT',
                wrap=True, wide=False,


### PR DESCRIPTION
The following pull request introduce the following changes : 

- Removing colors of application to the default white
- Added a space in the menu after the ressources
- Centring the loading pop-up
- Width of the menu is bigger and doesn't cut names anymore
- Cursor doesn't jump to the grid at the end of the menu