### PR TITLE
Fix the build of osc-tui binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 osc-tui:
-	python3 -m nuitka osc_tui/main.py -o exe --follow-imports --verbose -o osc-tui
+	python3 -m nuitka osc_tui/main.py -o exe --follow-imports --include-package=urllib3 -o osc-tui
 install:
 	sudo cp osc-tui /usr/local/bin
 uninstall:
 	sudo rm /usr/local/bin/osc-tui
+clean:
+	-rm -r main.build osc-tui


### PR DESCRIPTION
urllib3.exceptions was missing in the binary therefore we include it by default